### PR TITLE
fix: Windowsでadopt(8|11|14)-hotspotではなくtemurin(8|11|17)-jdkをインストール

### DIFF
--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -31,9 +31,9 @@ function Install-Package-By-Scoop {
   scoop install nvm yarn
   scoop install python
   scoop install go
-  scoop install adopt8-hotspot
-  scoop install adopt11-hotspot
-  scoop install adopt14-hotspot
+  scoop install temurin8-jdk
+  scoop install temurin11-jdk
+  scoop install temurin17-jdk
 }
 
 # Insatll-Package-By-Choco: cui関連のツールをインストールする (MySQLはScoopだとうまくいかなかったのでChocoに切り替え)


### PR DESCRIPTION
# 変更内容

- adopt(8|11|14)-hotspotではなくtemurin(8|11|17)-jdkをインストールするようにする。
    - Scoopの `java` バケットのadoptはtemurinにリネームされている。
    - 14は非LTSであり、サポートが終了している。
    - 現在の現行LTSは8、11、17